### PR TITLE
Modify PadIfNeeded logic : Add parameter size_ratio

### DIFF
--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -87,6 +87,7 @@ class PadIfNeeded(DualTransform):
         min_width (int): minimal result image width.
         pad_height_divisor (int): if not None, ensures image height is dividable by value of this argument.
         pad_width_divisor (int): if not None, ensures image width is dividable by value of this argument.
+        size_ratio(float): result image size ratio by original image size.
         border_mode (OpenCV flag): OpenCV border mode.
         value (int, float, list of int, list of float): padding value if border_mode is cv2.BORDER_CONSTANT.
         mask_value (int, float,
@@ -107,6 +108,7 @@ class PadIfNeeded(DualTransform):
         min_width: Optional[int] = 1024,
         pad_height_divisor: Optional[int] = None,
         pad_width_divisor: Optional[int] = None,
+        size_ration: Optional[float] = None,
         border_mode=cv2.BORDER_REFLECT_101,
         value=None,
         mask_value=None,
@@ -124,6 +126,7 @@ class PadIfNeeded(DualTransform):
         self.min_width = min_width
         self.pad_width_divisor = pad_width_divisor
         self.pad_height_divisor = pad_height_divisor
+        self.size_ratio = size_ratio
         self.border_mode = border_mode
         self.value = value
         self.mask_value = mask_value
@@ -132,6 +135,11 @@ class PadIfNeeded(DualTransform):
         params = super(PadIfNeeded, self).update_params(params, **kwargs)
         rows = params["rows"]
         cols = params["cols"]
+
+        if self.size_ratio is not None:
+            ratio = random.uniform(0.0, self.size_ratio)
+            self.min_height = rows + int(rows * ratio)
+            self.min_width = cols + int(cols * ratio)
 
         if self.min_height is not None:
             if rows < self.min_height:


### PR DESCRIPTION
### Segmentation augmentation에 사용하기 위해 PadIfNeeded 함수 기능 개선
* 기존 
  * 입력한 min width/height의 크기만큼만 영상크기를 변경
* 개선
  * size_ratio를 추가하여 입려된 ratio 범위안에서 random하게 min width/height크기를 계산하여 영상 크기를 변경
* 기타
  * size_ratio의 기본 값은 None으로 size_ratio값을 넣지 않으면 기존의 함수 동작방식대로 동작