### PR TITLE
Correct coordinate range: zero-base index

### DIFF
--- a/albumentations/augmentations/bbox_utils.py
+++ b/albumentations/augmentations/bbox_utils.py
@@ -67,6 +67,10 @@ def normalize_bbox(bbox, rows, cols):
         ValueError: If rows or cols is less or equal zero
 
     """
+    # Index of bbox array begins from 0
+    cols -= 1
+    rows -= 1
+
     (x_min, y_min, x_max, y_max), tail = bbox[:4], tuple(bbox[4:])
 
     if rows <= 0:
@@ -96,6 +100,10 @@ def denormalize_bbox(bbox, rows, cols):
         ValueError: If rows or cols is less or equal zero
 
     """
+    # Index of bbox array begins from 0
+    cols -= 1
+    rows -= 1
+    
     (x_min, y_min, x_max, y_max), tail = bbox[:4], tuple(bbox[4:])
 
     if rows <= 0:


### PR DESCRIPTION
:bug: BBOX 좌표 범위 수정

영상의 크기가 256일 때, 좌표 범위는 [0, 255] 여야하는데, 기존 코드는 [1, 256]의 좌표가 나오도록 되어있다.
분모 값이 0 베이스 인덱스를 고려하지 않았기 때문이다.

검증 코드

```
import albumentations as A
# 수직 변환 (Y 좌표 반전)
augments = A.Compose([A.VerticalFlip(p=1)],
                     bbox_params=A.BboxParams(format='coco', label_fields=['category_ids']))

img = np.zeros((256, 256, 3))
img = np.array(img, dtype=np.uint8)

# coco format
target = [{'bbox': [0, 0, 255, 255], 'category_id': 1},
              {'bbox': [0, 0, 10, 10], 'category_id': 2}]

bboxes = []
cat_ids = []
for gt in target:
    bboxes.append(gt['bbox'])
    cat_ids.append(gt['category_id'])

transformed = augments(image=img, bboxes=bboxes, category_ids=cat_ids)
bboxes = transformed['bboxes']

for bbox in bboxes:
    print(bbox)
```

OUTPUT
```
# master branch
(0.0, 1.0, 255.0, 255.0)
(0.0, 246.0, 10.0, 10.0)

# coordinate_range branch
(0.0, 0.0, 255.0, 255.0)
(0.0, 245.0, 10.0, 10.0)
```