### PR TITLE
Change parent

### DIFF
--- a/albumentations/augmentations/transforms.py
+++ b/albumentations/augmentations/transforms.py
@@ -681,7 +681,7 @@ class Cutout(ImageOnlyTransform):
         return ("num_holes", "max_h_size", "max_w_size")
 
 
-class CoarseDropout(DualTransform):
+class CoarseDropout(ImageOnlyTransform):
     """CoarseDropout of the rectangular regions in the image.
 
     Args:


### PR DESCRIPTION
CoarseDropout은 영상에 검은상자를 만드는 변환기법임

DualTransform을 상속하게 되면 필요한 함수가 구현되어 있지 않아 에러가 발생함.

ImageOnlyTransform을 상속해서 사용하도록 변경함

![image](https://user-images.githubusercontent.com/65634490/125044507-fbf9b000-e0d6-11eb-89da-3f326bf84a15.png)
